### PR TITLE
geobn.analysis: tornado sensitivity and value of information

### DIFF
--- a/docs/api/analysis.md
+++ b/docs/api/analysis.md
@@ -1,0 +1,13 @@
+# Sensitivity analysis
+
+One-way sensitivity (tornado) and value of information over a baseline
+evidence profile — which uncertain input most affects a decision, and
+which forecast is most worth verifying with a real measurement.
+
+::: geobn.analysis.tornado
+    options:
+      show_root_heading: true
+
+::: geobn.analysis.TornadoEntry
+    options:
+      show_root_heading: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,7 @@ nav:
     - GeoBayesianNetwork: api/network.md
     - Real-time optimisation: api/realtime.md
     - InferenceResult: api/result.md
+    - Analysis: api/analysis.md
     - Data Sources:
       - Overview: api/sources/index.md
       - Core sources: api/sources/core.md

--- a/src/geobn/analysis.py
+++ b/src/geobn/analysis.py
@@ -1,0 +1,161 @@
+"""Sensitivity analysis and value of information for decision support.
+
+Given a *baseline* evidence profile (the conditions you expect), rank the
+evidence nodes by how much they matter for a target posterior:
+
+- **Tornado swing** (one-way sensitivity): vary one evidence node over its
+  states with the rest of the baseline fixed; the swing is the max − min
+  of ``P(target = target_state)``. The classic tornado-diagram input.
+- **Value of information**: the expected reduction in Shannon entropy of
+  the target from observing the node, weighted by the node's predictive
+  distribution given the *rest* of the baseline. Pre-decision, the
+  "baseline observation" of a node is typically a forecast — VOI ranks
+  which forecast is most worth verifying with a real measurement.
+
+Example
+-------
+>>> import geobn
+>>> from geobn.analysis import tornado
+>>> bn = geobn.load("fire_risk.bif")
+>>> baseline = {"slope": "steep", "rainfall": "low"}
+>>> for entry in tornado(bn, "fire_risk", "high", baseline):
+...     print(entry.node, entry.swing, entry.voi_bits)
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import numpy as np
+from pgmpy.inference import VariableElimination
+from pgmpy.models import DiscreteBayesianNetwork
+
+_log = logging.getLogger(__name__)
+
+__all__ = ["TornadoEntry", "tornado"]
+
+
+@dataclass(frozen=True)
+class TornadoEntry:
+    """One-way sensitivity result for a single evidence node."""
+
+    node: str
+    #: max - min of P(target = target_state) across this node's states
+    swing: float
+    #: P(target = target_state) for each state of this node
+    p_by_state: dict[str, float]
+    #: the node's state in the supplied baseline
+    baseline_state: str
+    #: expected Shannon-entropy reduction of the target (bits) from
+    #: observing this node, given the rest of the baseline
+    voi_bits: float
+
+
+def _entropy_bits(p: np.ndarray) -> float:
+    p = p[p > 0]
+    return float(-(p * np.log2(p)).sum())
+
+
+def _resolve_model(bn) -> DiscreteBayesianNetwork:
+    """Accept either a GeoBayesianNetwork or a raw pgmpy network."""
+    if isinstance(bn, DiscreteBayesianNetwork):
+        return bn
+    model = getattr(bn, "_model", None)
+    if isinstance(model, DiscreteBayesianNetwork):
+        return model
+    raise TypeError(
+        f"Expected GeoBayesianNetwork or DiscreteBayesianNetwork, got {type(bn).__name__}"
+    )
+
+
+def tornado(
+    bn,
+    target: str,
+    target_state: str,
+    baseline: dict[str, str],
+) -> list[TornadoEntry]:
+    """One-way sensitivity + value of information for each baseline node.
+
+    Parameters
+    ----------
+    bn:
+        A :class:`~geobn.GeoBayesianNetwork` or a pgmpy
+        ``DiscreteBayesianNetwork``.
+    target:
+        The query node whose posterior is analysed.
+    target_state:
+        The state of *target* whose probability defines the swing.
+    baseline:
+        ``{evidence_node: state_name}`` — the reference conditions. Each
+        node in the baseline is varied in turn while the others stay fixed.
+
+    Returns
+    -------
+    list[TornadoEntry]
+        Sorted by decreasing swing.
+    """
+    model = _resolve_model(bn)
+    state_names = {
+        cpd.variable: list(cpd.state_names[cpd.variable]) for cpd in model.get_cpds()
+    }
+    if target not in state_names:
+        raise ValueError(f"Unknown target node '{target}'")
+    if target_state not in state_names[target]:
+        raise ValueError(
+            f"Unknown state '{target_state}' for '{target}'; "
+            f"expected one of {state_names[target]}"
+        )
+    for node, state in baseline.items():
+        if node not in state_names:
+            raise ValueError(f"Unknown baseline node '{node}'")
+        if state not in state_names[node]:
+            raise ValueError(
+                f"Unknown state '{state}' for '{node}'; expected one of {state_names[node]}"
+            )
+        if node == target:
+            raise ValueError(f"Target '{target}' cannot be part of the baseline evidence")
+
+    ve = VariableElimination(model)
+    t_idx = state_names[target].index(target_state)
+
+    entries: list[TornadoEntry] = []
+    for node, base_state in baseline.items():
+        rest = {k: v for k, v in baseline.items() if k != node}
+
+        p_by_state: dict[str, float] = {}
+        posteriors: list[np.ndarray] = []
+        for state in state_names[node]:
+            post = ve.query(
+                [target], evidence={**rest, node: state}, show_progress=False
+            ).values
+            p_by_state[state] = float(post[t_idx])
+            posteriors.append(post)
+
+        # VOI: predictive distribution of `node` given the rest of the baseline
+        predictive = ve.query([node], evidence=rest, show_progress=False).values
+        h_prior = _entropy_bits(ve.query([target], evidence=rest, show_progress=False).values)
+        h_expected = float(
+            sum(w * _entropy_bits(post) for w, post in zip(predictive, posteriors))
+        )
+
+        entries.append(
+            TornadoEntry(
+                node=node,
+                swing=max(p_by_state.values()) - min(p_by_state.values()),
+                p_by_state=p_by_state,
+                baseline_state=base_state,
+                voi_bits=max(h_prior - h_expected, 0.0),
+            )
+        )
+
+    entries.sort(key=lambda e: e.swing, reverse=True)
+    _log.info(
+        "Tornado on %s=%s over %d nodes; top driver: %s (swing %.3g)",
+        target,
+        target_state,
+        len(entries),
+        entries[0].node if entries else "n/a",
+        entries[0].swing if entries else 0.0,
+    )
+    return entries

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,0 +1,102 @@
+"""Tests for geobn.analysis — tornado sensitivity and value of information."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from pgmpy.inference import VariableElimination
+
+import geobn
+from geobn.analysis import tornado
+
+
+@pytest.fixture
+def baseline() -> dict[str, str]:
+    return {"slope": "steep", "rainfall": "low"}
+
+
+def test_tornado_swing_hand_computed(fire_risk_model, baseline):
+    """Swing must equal max-min of the directly computed posteriors."""
+    ve = VariableElimination(fire_risk_model)
+    entries = {e.node: e for e in tornado(fire_risk_model, "fire_risk", "high", baseline)}
+
+    high = list(
+        fire_risk_model.get_cpds("fire_risk").state_names["fire_risk"]
+    ).index("high")
+    p = {
+        s: float(
+            ve.query(
+                ["fire_risk"], evidence={"slope": s, "rainfall": "low"}, show_progress=False
+            ).values[high]
+        )
+        for s in ("flat", "moderate", "steep")
+    }
+    assert entries["slope"].swing == pytest.approx(max(p.values()) - min(p.values()), abs=1e-9)
+    assert entries["slope"].p_by_state == pytest.approx(p, abs=1e-9)
+    assert entries["slope"].baseline_state == "steep"
+
+
+def test_tornado_sorted_by_swing(fire_risk_model, baseline):
+    entries = tornado(fire_risk_model, "fire_risk", "high", baseline)
+    swings = [e.swing for e in entries]
+    assert swings == sorted(swings, reverse=True)
+    assert {e.node for e in entries} == set(baseline)
+
+
+def test_voi_nonnegative_and_zero_for_irrelevant_node(fire_risk_model, baseline):
+    entries = {e.node: e for e in tornado(fire_risk_model, "fire_risk", "high", baseline)}
+    assert all(e.voi_bits >= 0.0 for e in entries.values())
+    # both parents influence fire_risk in this model, so VOI is strictly positive
+    assert entries["slope"].voi_bits > 0.0
+    assert entries["rainfall"].voi_bits > 0.0
+
+
+def test_voi_hand_computed(fire_risk_model, baseline):
+    """VOI(slope) = H(target | rest) - E_slope[H(target | rest, slope)]."""
+    ve = VariableElimination(fire_risk_model)
+
+    def entropy(p: np.ndarray) -> float:
+        p = p[p > 0]
+        return float(-(p * np.log2(p)).sum())
+
+    rest = {"rainfall": "low"}
+    h_prior = entropy(ve.query(["fire_risk"], evidence=rest, show_progress=False).values)
+    predictive = ve.query(["slope"], evidence=rest, show_progress=False).values
+    states = list(fire_risk_model.get_cpds("slope").state_names["slope"])
+    h_expected = sum(
+        w
+        * entropy(
+            ve.query(
+                ["fire_risk"], evidence={**rest, "slope": s}, show_progress=False
+            ).values
+        )
+        for w, s in zip(predictive, states)
+    )
+    expected_voi = max(h_prior - h_expected, 0.0)
+
+    entries = {e.node: e for e in tornado(fire_risk_model, "fire_risk", "high", baseline)}
+    assert entries["slope"].voi_bits == pytest.approx(expected_voi, abs=1e-9)
+
+
+def test_accepts_geo_bayesian_network(fire_risk_model, baseline):
+    bn = geobn.GeoBayesianNetwork(fire_risk_model)
+    from_wrapper = tornado(bn, "fire_risk", "high", baseline)
+    from_model = tornado(fire_risk_model, "fire_risk", "high", baseline)
+    assert [(e.node, e.swing) for e in from_wrapper] == [
+        (e.node, e.swing) for e in from_model
+    ]
+
+
+def test_validation_errors(fire_risk_model, baseline):
+    with pytest.raises(ValueError, match="Unknown target"):
+        tornado(fire_risk_model, "nope", "high", baseline)
+    with pytest.raises(ValueError, match="Unknown state 'extreme'"):
+        tornado(fire_risk_model, "fire_risk", "extreme", baseline)
+    with pytest.raises(ValueError, match="Unknown baseline node"):
+        tornado(fire_risk_model, "fire_risk", "high", {"wind": "low"})
+    with pytest.raises(ValueError, match="cannot be part of the baseline"):
+        tornado(
+            fire_risk_model, "fire_risk", "high", {"fire_risk": "low", "slope": "flat"}
+        )
+    with pytest.raises(TypeError, match="Expected GeoBayesianNetwork"):
+        tornado("not a model", "fire_risk", "high", baseline)


### PR DESCRIPTION
## What

New `geobn.analysis` module for decision support on top of a BN:

- **`tornado(bn, target, target_state, baseline)`** — one-way sensitivity: each baseline evidence node is varied over its states with the rest fixed; entries report the posterior swing (max−min of `P(target=target_state)`), the per-state posteriors, and the **value of information** (expected Shannon-entropy reduction of the target from observing the node, weighted by its predictive distribution given the rest of the baseline). Returns `TornadoEntry` records sorted by swing.

Accepts either a `GeoBayesianNetwork` or a raw pgmpy `DiscreteBayesianNetwork`.

## Why

When a geobn risk map feeds a decision (GO/NO-GO, route choice), the natural follow-up questions are "which input drives this?" and "which forecast is worth verifying with a real measurement before committing?". VOI answers the second: pre-decision, a node's baseline 'observation' is typically a forecast, and ranking by expected entropy reduction identifies the measurement with the highest information payoff. This is the "top risk drivers" table in [iceguard](https://github.com/jensbremnes/iceguard)'s pre-mission decision reports, upstreamed.

## Tests / docs

6 new tests in `tests/test_analysis.py` including hand-computed swing and VOI checks against direct `VariableElimination`, ordering, wrapper-vs-raw-model equivalence, and validation errors. Full suite: 122 passed. New `docs/api/analysis.md` registered in the mkdocs nav.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
